### PR TITLE
remove usage of pip's --process-dependency-links option (removed in pip 19.0)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,7 +13,7 @@ RUN set -ex \
  && sudo pip3 install virtualenv \
  && virtualenv --system-site-packages env \ 
  && source env/bin/activate \
- && pip install --process-dependency-links -e . \
+ && pip install -e . \
  && pytest --junit-xml=/tmp/pytest_unit.xml || : \
  && pytest --cov giant_time_series --cov-report=html:/tmp/coverage.html || : \
  && flake8 --exclude=env --exit-zero --statistics \


### PR DESCRIPTION
As per https://github.com/hysds/giant_time_series/commit/f7815a81407b709c0157146e27e9b30ce4df7de4