### PR TITLE
roll back pip to 18.0 in virtualenv to get around pandas issue with versioneer pip 19.0

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,7 +13,8 @@ RUN set -ex \
  && sudo pip3 install virtualenv \
  && virtualenv --system-site-packages env \ 
  && source env/bin/activate \
- && pip install -e . \
+ && pip install pip==18.0.0 \
+ && pip install --process-dependency-links -e . \
  && pytest --junit-xml=/tmp/pytest_unit.xml || : \
  && pytest --cov giant_time_series --cov-report=html:/tmp/coverage.html || : \
  && flake8 --exclude=env --exit-zero --statistics \


### PR DESCRIPTION
Somehow pip 19.0 has an issue in importing `versioneer` for `pip install pandas` even though versioneer has already been installed with `pip install versioneer`: 

testing it within docker [here](https://gist.github.com/shitong01/acfcd96a874d4dcbfa015a210f048dd3#file-00-pip-install-pandas-fail-with-pip-19-0-even-though-versioneer-is-installed)
original error with CI Build LOGs [here](https://gist.github.com/shitong01/acfcd96a874d4dcbfa015a210f048dd3#file-pip-19-0-failed-to-install-pandas-when-building-giant_time_series-docker-L94-L136)

Stack job [run](https://mozart.earthobservatory.sg/figaro/?base64=eyJxdWVyeSI6eyJib29sIjp7Im11c3QiOlt7InRlcm0iOnsic3RhdHVzIjoiam9iLWZhaWxlZCJ9fSx7InRlcm0iOnsiY2VsZXJ5X2hvc3RuYW1lIjoiY2VsZXJ5QGNoYW5nZV9kZXRlY3Rpb24tam9iX3dvcmtlci1sYXJnZS4xNzIuMzEuNDIuMjMyIn19XX19LCJzaXplIjoyNSwic29ydCI6W3siQHRpbWVzdGFtcCI6eyJvcmRlciI6ImRlc2MifX1dLCJmaWVsZHMiOlsiQHRpbWVzdGFtcCJdLCJwYXJ0aWFsX2ZpZWxkcyI6eyJfc291cmNlIjp7ImV4Y2x1ZGUiOlsiam9iLmpvYl9pbmZvLm1ldHJpY3MiLCJjb250ZXh0LmNvbnRleHQiLCJjb250ZXh0LmxvY2FsaXplX3VybHMiLCJqb2IuY29udGV4dC5jb250ZXh0Iiwiam9iLmNvbnRleHQuam9iX3NwZWNpZmljYXRpb24ucGFyYW1zIiwiam9iLmNvbnRleHQubG9jYWxpemVfdXJscyIsImpvYi5sb2NhbGl6ZV91cmxzIiwiam9iLnBhcmFtcyJdfX19), with no complaints of `Failed to import pandas`